### PR TITLE
Fix flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,9 +2,12 @@
 max-line-length = 80
 max-complexity = 12
 extend-ignore =
-    E203  # https://github.com/PyCQA/pycodestyle/issues/373
-    E501  # for flake8-bugbear
-    W503  # https://www.flake8rules.com/rules/W503.html
+    # https://github.com/PyCQA/pycodestyle/issues/373
+    E203
+    # for flake8-bugbear
+    E501
+    # https://www.flake8rules.com/rules/W503.html
+    W503
 extend-select = B950
 exclude =
     .git


### PR DESCRIPTION

Flake8 version 6 now breaks on inline comments in the config.
This is a workaround for that. See https://github.com/PyCQA/flake8/issues/1756
