### PR TITLE
Skip proxy models

### DIFF
--- a/leukeleu_django_gdpr/gdpr.py
+++ b/leukeleu_django_gdpr/gdpr.py
@@ -80,6 +80,8 @@ class Serializer:
 
     def handle_app(self, app_config):
         for model in app_config.get_models():
+            if model._meta.proxy:
+                continue  # Skip proxy models
             if self.should_include(model):
                 yield self.handle_model(model)
 

--- a/tests/custom_users/models.py
+++ b/tests/custom_users/models.py
@@ -16,3 +16,8 @@ class SpecialUser(CustomUser):
     speciality = models.CharField(
         _("Speciality"), max_length=255, null=True, blank=True
     )
+
+
+class ProxyUser(CustomUser):
+    class Meta:
+        proxy = True

--- a/tests/test_commands/test_serializer.py
+++ b/tests/test_commands/test_serializer.py
@@ -16,6 +16,8 @@ class SerializerTest(TestCase):
                 "auth.Permission",
                 "custom_users.CustomUser",
                 "custom_users.SpecialUser",
+                # Does not include proxy models:
+                # "custom_users.ProxyUser"
             },
         )
 


### PR DESCRIPTION
Proxy models will always have the same fields as the model they are proxying, they can be excluded by default

Fixes issue #9