### PR TITLE
Make sure the gdpr.yml file can be read back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 History
 -------
 
+* 1.3.1 (unreleased)
+  
+  * Fix serialization of SafeString values
+
 * 1.3.0 (2022-12-08)
 
   * Add an option to override gdpr.yml output directory

--- a/tests/custom_users/models.py
+++ b/tests/custom_users/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from django.utils.html import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 
@@ -14,7 +15,15 @@ class CustomUser(AbstractUser):
 
 class SpecialUser(CustomUser):
     speciality = models.CharField(
-        _("Speciality"), max_length=255, null=True, blank=True
+        _("Speciality"),
+        max_length=255,
+        null=True,
+        blank=True,
+        help_text=mark_safe(
+            _(
+                "Speciality of the user. <a href='https://example.com' target='_blank'>More info</a>"
+            )
+        ),
     )
 
 

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,0 +1,21 @@
+import shutil
+import tempfile
+
+from django.test import TestCase
+
+from leukeleu_django_gdpr.gdpr import Serializer, get_gdpr_yml_path, read_data
+
+
+class TestSerializerDataRoundTrip(TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp_dir)
+
+    def test_load_serializer_data(self):
+        with self.settings(DJANGO_GDPR_YML_DIR=self.tmp_dir):
+            serializer = Serializer()
+            serializer.generate_models_list()
+            with open(get_gdpr_yml_path(), "w") as f:
+                serializer.save(f)
+
+            self.assertEqual(serializer.models, read_data().get("models"))


### PR DESCRIPTION
Fixes an issue where Django's SafeString were serialized in a way that could not be loaded