### PR TITLE
Add anonymization command

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,49 @@ include:
 Proxy models are always excluded. They are the same as the model they proxy,
 so there is no benefit in including them.
 
+## Anonymizing data
+
+Leukeleu-django-gdpr comes with a `anonymize` management command.
+
+```
+./manage.py anonymize
+```
+
+(You can only run this command when `DEBUG=True`. It's meant to run locally)
+
+This command uses the `gdpr.yaml` file to anonymize all PII fields in the database. 
+By default, it will anonymize **all fields** that contain PII.
+
+To change the configuration, you can create a subclass of `BaseAnonymizer`:
+
+```python
+# some_file.py
+class Anonymizer(BaseAnonymizer):
+    # To skip rows
+    extra_qs_overrides = {
+        "auth.User": User._base_manager.exclude(is_superuser=True),
+        ...
+    }
+
+    # To change what fake data should be used for a field
+    extra_field_overrides = {
+        "auth.User.first_name": fake.first_name,
+        ...
+    }
+
+    # To skip fields
+    excluded_fields = [
+        "auth.User.email",  # Usually you should not exclude emails
+        ...
+    ]
+```
+
+Then add this setting to your settings file:
+
+```python
+DJANGO_GDPR_ANONYMIZER_CLASS = "location.to.custom.Anonymizer"
+```
+
 ## Checks
 
 Leukeleu-django-gdpr adds a `gdpr.I001` check to the `check` command. This check will fail if

--- a/README.md
+++ b/README.md
@@ -140,22 +140,41 @@ To change the configuration, you can create a subclass of `BaseAnonymizer`:
 
 ```python
 # some_file.py
+
+fake = Faker(["nl-NL"])
+
+
 class Anonymizer(BaseAnonymizer):
-    # To skip rows
+    # Exclude rows
+    # Default: superusers and staff users are excluded
     extra_qs_overrides = {
-        "auth.User": User._base_manager.exclude(is_superuser=True),
+        "app.Model": Model._base_manager.exclude(some_field=...),
         ...
     }
 
-    # To change what fake data should be used for a field
+    # Specify fake data for a field
+    # Default: user's first_name and last_name are filled with random first/last names
     extra_field_overrides = {
-        "auth.User.first_name": fake.first_name,
+        "app.Model.some_field": fake.word,
+        "app.Model.some_other_field": lambda: "same value for every cell",
+        ...
+    }
+    
+    # Specify the fake data used for a field type
+    # Use for custom fields or to overwrite defaults
+    # Default: django builtin fields have "sensible" defaults
+    extra_fieldtype_overrides = {
+        "CustomPhoneNumberField": fake.phone_number,
+      
+        # Also specify a unique variant (append with ".unique")
+        "CustomPhoneNumberField.unique": fake.unique.phone_number,
         ...
     }
 
-    # To skip fields
+    # Exclude fields
+    # Default: no fields are excluded
     excluded_fields = [
-        "auth.User.email",  # Usually you should not exclude emails
+        "app.SomeModel.some_field",
         ...
     ]
 ```

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -22,18 +22,22 @@ class BaseAnonymizer:
     """
     Base class for anonymizing data.
 
+    By default:
+        - superusers and staff users are excluded from anonymization
+        - the user's first_name and last_name are filled with fake first/last names
+
     Options:
         excluded_fields: List of fields to exclude from anonymization
-            example: ["auth.User.email"]
+            example: ["app.Model.field"]
 
         extra_fieldtype_overrides: Dict of field type overrides
-            example: {"CharField": fake.pystr}
+            example: {"CustomPhoneNumberField": fake.phone_number}
 
         extra_qs_overrides: Dict of queryset overrides
-            example: {"auth.User": User.objects.exclude(is_superuser=True)}
+            example: {"app.Model": Model.objects.exclude(some_field=...)}
 
         extra_field_overrides: Dict of field overrides
-            example: {"auth.User.email": fake.email}
+            example: {"app.Model.field": fake.word}
     """
 
     excluded_fields = []

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -19,6 +19,23 @@ def get_models_from_gdpr_yml():
 
 
 class BaseAnonymizer:
+    """
+    Base class for anonymizing data.
+
+    Options:
+        excluded_fields: List of fields to exclude from anonymization
+            example: ["auth.User.email"]
+
+        extra_fieldtype_overrides: Dict of field type overrides
+            example: {"CharField": fake.pystr}
+
+        extra_qs_overrides: Dict of queryset overrides
+            example: {"auth.User": User.objects.exclude(is_superuser=True)}
+
+        extra_field_overrides: Dict of field overrides
+            example: {"auth.User.email": fake.email}
+    """
+
     excluded_fields = []
     extra_fieldtype_overrides = None
     extra_qs_overrides = None
@@ -61,8 +78,7 @@ class BaseAnonymizer:
                         )
                     except KeyError:
                         raise ImproperlyConfigured(
-                            f"Field type '{field_type}' not defined "
-                            "inside FIELDTYPE_FAKER_MAPPING"
+                            f"Unknown field type: '{field_type}'"
                         )
 
                     for obj in qs:

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -1,0 +1,140 @@
+from functools import partial
+
+from faker import Faker
+
+from django.apps import apps
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
+from django.db import transaction
+from django.db.models import Q
+
+from leukeleu_django_gdpr.gdpr import read_data
+
+
+def get_models_from_gdpr_yml():
+    data = read_data()
+    return data["models"]
+
+
+class BaseAnonymizer:
+    excluded_fields = []
+    extra_fieldtype_overrides = None
+    extra_qs_overrides = None
+    extra_field_overrides = None
+
+    def __init__(self):
+        self.fake = Faker(["nl-NL"])
+
+    def anonymize(self):
+        fieldtype_overrides = self.get_fieldtype_overrides()
+        qs_overrides = self.get_qs_overrides()
+        field_overrides = self.get_field_overrides()
+
+        with transaction.atomic():
+            models = get_models_from_gdpr_yml()
+            for model_name, model_data in models.items():
+                print(f"Currently anonymizing: {model_name}")
+
+                Model = apps.get_model(model_name)  # noqa: N806
+
+                qs = qs_overrides.get(model_name, Model._base_manager.all())
+                qs = qs.all()  # Makes sure we are always dealing with the latest data
+
+                for field_name, field_data in model_data["fields"].items():
+                    field_path = f"{model_name}.{field_name}"
+                    if not field_data["pii"] or field_path in self.excluded_fields:
+                        # Leave non PII and ignored fields alone
+                        continue
+
+                    field = Model._meta.get_field(field_name)
+
+                    field_type = type(field).__name__
+                    if field.unique:
+                        field_type += ".unique"
+
+                    try:
+                        value_func = field_overrides.get(
+                            field_path,
+                            fieldtype_overrides[field_type],
+                        )
+                    except KeyError:
+                        raise ImproperlyConfigured(
+                            f"Field type '{field_type}' not defined "
+                            "inside FIELDTYPE_FAKER_MAPPING"
+                        )
+
+                    for obj in qs:
+                        setattr(obj, field_name, value_func())
+
+                Model.objects.bulk_update(
+                    qs,
+                    model_data["fields"].keys(),
+                    batch_size=500,
+                )
+
+    def get_fieldtype_overrides(self):
+        fieldtype_overrides = {
+            "BigIntegerField": self.fake.random_int,
+            "BigIntegerField.unique": self.fake.unique.random_int,
+            "BooleanField": self.fake.boolean,  # No unique variant
+            "CharField": self.fake.pystr,
+            "CharField.unique": self.fake.unique.pystr,
+            "DateField": self.fake.date_this_decade,
+            "DateField.unique": self.fake.unique.date_this_decade,
+            "DateTimeField": self.fake.date_time_this_decade,
+            "DateTimeField.unique": self.fake.unique.date_time_this_decade,
+            "DecimalField": self.fake.random_int,
+            "DecimalField.unique": self.fake.unique.random_int,
+            "EmailField": self.fake.safe_email,
+            "EmailField.unique": self.fake.unique.safe_email,
+            "FloatField": self.fake.random_int,
+            "FloatField.unique": self.fake.unique.random_int,
+            "GenericIPAddressField": self.fake.ipv4,
+            "GenericIPAddressField.unique": self.fake.unique.ipv4,
+            "IntegerField": self.fake.random_int,
+            "IntegerField.unique": self.fake.unique.random_int,
+            "JSONField": partial(
+                self.fake.pydict,
+                value_types=["str"],
+            ),  # No unique variant
+            "PositiveBigIntegerField": self.fake.random_int,
+            "PositiveBigIntegerField.unique": self.fake.unique.random_int,
+            "PositiveIntegerField": self.fake.random_int,
+            "PositiveIntegerField.unique": self.fake.unique.random_int,
+            "PositiveSmallIntegerField": self.fake.random_int,
+            "PositiveSmallIntegerField.unique": self.fake.unique.random_int,
+            "RichTextField": self.fake.paragraph,
+            "RichTextField.unique": self.fake.unique.paragraph,
+            "SlugField": self.fake.pystr,
+            "SlugField.unique": self.fake.unique.pystr,
+            "SmallIntegerField": self.fake.random_int,
+            "SmallIntegerField.unique": self.fake.unique.random_int,
+            "TextField": self.fake.paragraph,
+            "TextField.unique": self.fake.unique.paragraph,
+            "URLField": self.fake.url,
+            "URLField.unique": self.fake.unique.url,
+        }
+
+        if self.extra_fieldtype_overrides is not None:
+            fieldtype_overrides.update(self.extra_fieldtype_overrides)
+        return fieldtype_overrides
+
+    def get_qs_overrides(self):
+        qs_overrides = {
+            settings.AUTH_USER_MODEL: get_user_model()._base_manager.exclude(
+                Q(is_superuser=True) | Q(is_staff=True)
+            ),
+        }
+        if self.extra_qs_overrides is not None:
+            qs_overrides.update(self.extra_qs_overrides)
+        return qs_overrides
+
+    def get_field_overrides(self):
+        field_overrides = {
+            f"{settings.AUTH_USER_MODEL}.first_name": self.fake.first_name,
+            f"{settings.AUTH_USER_MODEL}.last_name": self.fake.last_name,
+        }
+        if self.extra_field_overrides is not None:
+            field_overrides.update(self.extra_field_overrides)
+        return field_overrides

--- a/leukeleu_django_gdpr/management/commands/anonymize.py
+++ b/leukeleu_django_gdpr/management/commands/anonymize.py
@@ -21,10 +21,8 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
-        if not settings.DATABASES["default"]["NAME"].endswith("_anonymized"):
-            raise CommandError(
-                "You can only anonymize a database that ends with `_anonymized`."
-            )
+        if not settings.DEBUG:
+            raise CommandError("You can only run this command in DEBUG mode.")
 
         stats = get_pii_stats(save=False)
         unclassified_fields = stats.get(None, 0)

--- a/leukeleu_django_gdpr/management/commands/anonymize.py
+++ b/leukeleu_django_gdpr/management/commands/anonymize.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.core.management import BaseCommand, CommandError
+from django.utils.module_loading import import_string
+
+from leukeleu_django_gdpr.anonymize import BaseAnonymizer
+from leukeleu_django_gdpr.gdpr import get_pii_stats
+
+
+def get_anonymizer():
+    if hasattr(settings, "DJANGO_GDPR_ANONYMIZER_CLASS"):
+        return import_string(settings.DJANGO_GDPR_ANONYMIZER_CLASS)()
+    else:
+        return BaseAnonymizer()
+
+
+class Command(BaseCommand):
+    """
+    Goes through models and their fields and anonymizes the data if `pii: True`
+
+    Currently, fields that are *not* required will still be anonymized.
+    """
+
+    def handle(self, *args, **options):
+        if not settings.DATABASES["default"]["NAME"].endswith("_anonymized"):
+            raise CommandError(
+                "You can only anonymize a database that ends with `_anonymized`."
+            )
+
+        stats = get_pii_stats(save=False)
+        unclassified_fields = stats.get(None, 0)
+        if unclassified_fields:
+            raise CommandError(
+                f"There are still {unclassified_fields} unclassified PII fields. "
+                "Run `manage.py gdpr` first and classify all fields."
+            )
+
+        get_anonymizer().anonymize()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Successfully anonymized data. Make sure to check it.",
+            )
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ python_requires = >=3.6
 packages = find:
 install_requires =
     Django
+    Faker
     pyyaml
 
 [options.packages.find]

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -1,0 +1,123 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from leukeleu_django_gdpr.anonymize import BaseAnonymizer
+from tests.custom_users.models import CustomUser
+
+
+def _get_models():
+    return {
+        "custom_users.CustomUser": {
+            "fields": {
+                "username": {
+                    "pii": True,
+                },
+                "first_name": {
+                    "pii": True,
+                },
+            }
+        }
+    }
+
+
+patch_get_models = mock.patch(
+    "leukeleu_django_gdpr.anonymize.get_models_from_gdpr_yml",
+    return_value=_get_models(),
+)
+
+
+class AnonymizerTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        patch_get_models.start()
+        cls.addClassCleanup(patch_get_models.stop)
+
+    def setUp(self):
+        self.user = CustomUser.objects.create(username="User", first_name="John")
+        self.superuser = CustomUser.objects.create(username="Super", is_superuser=True)
+        self.staffuser = CustomUser.objects.create(username="Staff", is_staff=True)
+
+    def test_username_anonymization(self):
+        self.assertEqual(self.user.username, "User")
+        self.assertEqual(self.superuser.username, "Super")
+        self.assertEqual(self.staffuser.username, "Staff")
+
+        BaseAnonymizer().anonymize()
+
+        self.user.refresh_from_db()
+        self.superuser.refresh_from_db()
+        self.staffuser.refresh_from_db()
+
+        # This should be different now
+        self.assertNotEqual(self.user.username, "User")
+
+        # These should still equal the original usernames
+        self.assertEqual(self.superuser.username, "Super")
+        self.assertEqual(self.staffuser.username, "Staff")
+
+    def test_excluded_fields(self):
+        class Anonymizer(BaseAnonymizer):
+            excluded_fields = [
+                "custom_users.CustomUser.username",
+            ]
+
+        self.assertEqual(self.user.username, "User")
+        Anonymizer().anonymize()
+        self.user.refresh_from_db()
+
+        # This should still equal the original username
+        self.assertEqual(self.user.username, "User")
+
+    def test_extra_fieldtypes(self):
+        class Anonymizer(BaseAnonymizer):
+            extra_fieldtype_overrides = {
+                "CharField": lambda: "Foo",
+            }
+
+            def get_field_overrides(self):
+                return {}
+
+        self.assertEqual(self.user.first_name, "John")
+        Anonymizer().anonymize()
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.first_name, "Foo")
+
+    def test_extra_qs_overrides(self):
+        class Anonymizer(BaseAnonymizer):
+            extra_qs_overrides = {
+                # By default superusers would be skipped
+                "custom_users.CustomUser": CustomUser._base_manager.all(),
+            }
+
+        self.assertEqual(self.superuser.username, "Super")
+        Anonymizer().anonymize()
+        self.superuser.refresh_from_db()
+
+        # This should be different now
+        self.assertNotEqual(self.superuser.username, "Super")
+
+    def test_extra_field_overrides(self):
+        class Anonymizer(BaseAnonymizer):
+            extra_field_overrides = {
+                "custom_users.CustomUser.username": lambda: "Foo",
+            }
+
+        self.assertEqual(self.user.username, "User")
+        Anonymizer().anonymize()
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, "Foo")
+
+    def test_multiple_runs_while_new_data_is_added(self):
+        class Anonymizer(BaseAnonymizer):
+            extra_qs_overrides = {
+                "custom_users.CustomUser": CustomUser._base_manager.all(),
+            }
+
+        Anonymizer().anonymize()
+        new_user = CustomUser.objects.create(username="NewUser")
+        Anonymizer().anonymize()
+        new_user.refresh_from_db()
+        self.assertNotEqual(new_user.username, "NewUser")

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -16,6 +16,9 @@ def _get_models():
                 "first_name": {
                     "pii": True,
                 },
+                "last_name": {
+                    "pii": True,
+                },
             }
         }
     }
@@ -39,6 +42,21 @@ class AnonymizerTest(TestCase):
         self.user = CustomUser.objects.create(username="User", first_name="John")
         self.superuser = CustomUser.objects.create(username="Super", is_superuser=True)
         self.staffuser = CustomUser.objects.create(username="Staff", is_staff=True)
+
+    def test_empty_fields_are_skipped(self):
+        user_without_last_name = CustomUser.objects.create(
+            first_name="First name",
+        )
+        self.assertEqual(user_without_last_name.last_name, "")
+
+        BaseAnonymizer().anonymize()
+        user_without_last_name.refresh_from_db()
+
+        # This should be different now
+        self.assertNotEqual(user_without_last_name.first_name, "First name")
+
+        # Last name should still be empty
+        self.assertEqual(user_without_last_name.last_name, "")
 
     def test_username_anonymization(self):
         self.assertEqual(self.user.username, "User")


### PR DESCRIPTION
Ik vond dit zelf de meest logische plek. Geen idee of dit een juiste aanpak is though.

Voorbeeld gebruik in 99gram: https://github.com/leukeleu/99gram/compare/main...example-implementation-anonymization.

@wadevries Dennis ziet graag een commando (`Makefile`) waarmee je een productie DB kopieert => anonimiseert => exporteert naar staging. Valt dit onder de mogelijkheden? Zou je daarmee kunnen helpen eventueel?