### PR TITLE
Optional anonimyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 History
 -------
 
+* 1.5.1 (2024-03-06)
+
+  * Make anonymisation dependency optional
+
 * 1.5.0 (2024-03-04)
 
   * Add anonymisation management command

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 test: flaketest isorttest coveragetest
 
 devinstall:
-	pip install --upgrade --upgrade-strategy eager -e .[test]
+	pip install --upgrade --upgrade-strategy eager -e .[test,anonymize]
 
 flaketest:
 	# Check syntax and style

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ pip install leukeleu-django-gdpr[anonymize]
 ./manage.py anonymize
 ```
 
-This command uses the `gdpr.yaml` file to anonymize all PII fields in the database. 
-By default, it will anonymize **all fields** that contain PII.
+This command uses the `gdpr.yaml` file to anonymize **all fields marked 
+as PII** in the database.
 
 To change the configuration, you can create a subclass of `BaseAnonymizer`:
 
@@ -199,7 +199,5 @@ there are any `pii: null` values in the yaml file. To run the check, run:
 
 ## CI/CD
 
-To run this in CI/CD you need to ensure this package can be installed from
-wherever this package is indexed. Run it with `--check` to make a (scheduled?) CI/CD task
-fail if there are unclassified fields, which can happen if someone adds a field to a model
-but forgets to mark it as (non-) PII in the gdpr.yml.
+Run the `check` command to make a (scheduled) CI/CD task fail if there are unclassified fields, 
+which can happen if someone adds a field to a model but forgets to classify it in the `gdpr.yml`.

--- a/README.md
+++ b/README.md
@@ -125,13 +125,16 @@ so there is no benefit in including them.
 
 ## Anonymizing data
 
-Leukeleu-django-gdpr comes with a `anonymize` management command.
+Leukeleu-django-gdpr comes with a `anonymize` management command, that
+anonymizes all PII fields in the database. 
+
+It is meant to be used in development only. It requires an additional 
+dependency and setting `DEBUG = True`.
 
 ```
+pip install leukeleu-django-gdpr[anonymize]
 ./manage.py anonymize
 ```
-
-(You can only run this command when `DEBUG=True`. It's meant to run locally)
 
 This command uses the `gdpr.yaml` file to anonymize all PII fields in the database. 
 By default, it will anonymize **all fields** that contain PII.

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ python_requires = >=3.6
 packages = find:
 install_requires =
     Django
-    Faker
     pyyaml
 
 [options.packages.find]
@@ -29,6 +28,8 @@ exclude =
     tests.*
 
 [options.extras_require]
+anonymize =
+    Faker
 test =
     # Linting
     black~=24.1


### PR DESCRIPTION
I noticed that Faker is now installed for every project because of the recent update to this package. Since it's not actually possible to run the code that requires this dependency on staging/production I propose to make it optional.