### PR TITLE
Use uv as ecosystem for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: 'weekly'
 
-  - package-ecosystem: 'pip'
+  - package-ecosystem: 'uv'
     directory: '/'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
This should ensure the uv.lock is also kept up to date.