### PR TITLE
LKL-2561 remove need for lambdas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,11 @@ lint:
 	uv run ruff format --check --diff
 	$(call endgroup)
 
+tests ?= tests
 .PHONY: unittests
 unittests:
 	# Run unit tests with coverage
-	uv run coverage run ./runtests.py
+	uv run coverage run ./runtests.py $(tests) --shuffle --no-input --durations 10
 
 .PHONY: coveragetest
 coveragetest: unittests

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ class Anonymizer(BaseAnonymizer):
       
         # Also specify a unique variant (append with ".unique")
         "CustomPhoneNumberField.unique": fake.unique.phone_number,
+        
+        # Use functools.partial to set arguments for simple functions
+        "CustomRegionField": partial(fake.words, nb=4),
 
         # You can also use full custom functions for more complex behaviour
         "ImageHash": custom_anonymizer,

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ as PII** in the database.
 
 To change the configuration, you can create a subclass of `BaseAnonymizer`:
 
-Note that anonymizer functions should conform to the `leukeleu_django_gdpr.anonmymize.AnonymizerFunction` protocol.
+Note that anonymizer functions should either conform to the
+`leukeleu_django_gdpr.anonymize.AnonymizerFunction` protocol or be functions that do
+not need to take any arguments.
 
 ```python
 # some_file.py
@@ -162,8 +164,8 @@ class Anonymizer(BaseAnonymizer):
     # Specify fake data for a field
     # Default: user's first_name and last_name are filled with random first/last names
     extra_field_overrides = {
-        "app.Model.some_field": lambda obj, field: fake.word(),
-        "app.Model.some_other_field": lambda obj, field: "same value for every cell",
+        "app.Model.some_field": fake.word,
+        "app.Model.some_other_field": lambda: "same value for every cell",
         ...
     }
     
@@ -171,10 +173,10 @@ class Anonymizer(BaseAnonymizer):
     # Use for custom fields or to overwrite defaults
     # Default: django builtin fields have "sensible" defaults
     extra_fieldtype_overrides = {
-        "CustomPhoneNumberField": lambda obj, field: fake.phone_number(),
+        "CustomPhoneNumberField": fake.phone_number,
       
         # Also specify a unique variant (append with ".unique")
-        "CustomPhoneNumberField.unique": lambda obj, field: fake.unique.phone_number(),
+        "CustomPhoneNumberField.unique": fake.unique.phone_number,
 
         # You can also use full custom functions for more complex behaviour
         "ImageHash": custom_anonymizer,

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -4,6 +4,7 @@ import uuid
 from collections.abc import Callable, Mapping
 from functools import partial
 from importlib import resources
+from types import MappingProxyType
 from typing import Any, Protocol, TypeIs
 
 from faker import Faker
@@ -116,9 +117,9 @@ class BaseAnonymizer:
     """
 
     excluded_fields = []
-    extra_fieldtype_overrides: dict[str, AllowedOverrides] | None = None
+    extra_fieldtype_overrides: Mapping[str, AllowedOverrides] | None = None
     extra_qs_overrides = None
-    extra_field_overrides: dict[str, AllowedOverrides] | None = None
+    extra_field_overrides: Mapping[str, AllowedOverrides] | None = None
 
     def __init__(self):
         self.fake = Faker(["nl-NL"])
@@ -184,48 +185,50 @@ class BaseAnonymizer:
                     )
 
     def get_fieldtype_overrides(self) -> Mapping[str, AllowedOverrides]:
-        fieldtype_overrides = {
-            "BigIntegerField": self.fake.random_int,
-            "BigIntegerField.unique": self.fake.unique.random_int,
-            "BooleanField": self.fake.boolean,  # No unique varit
-            "CharField": self.fake.pystr,
-            "CharField.unique": self.fake.unique.pystr,
-            "DateField": self.fake.date_this_decade,
-            "DateField.unique": self.fake.unique.date_this_decade,
-            "DateTimeField": self.fake.date_time_this_decade,
-            "DateTimeField.unique": self.fake.unique.date_time_this_decade,
-            "DecimalField": self.fake.random_int,
-            "DecimalField.unique": self.fake.unique.random_int,
-            "EmailField": self.fake.safe_email,
-            "EmailField.unique": self.fake.unique.safe_email,
-            "FloatField": self.fake.random_int,
-            "FloatField.unique": self.fake.unique.random_int,
-            "GenericIPAddressField": self.fake.ipv4,
-            "GenericIPAddressField.unique": self.fake.unique.ipv4,
-            "ImageField": anonymize_image_field,
-            "IntegerField": self.fake.random_int,
-            "IntegerField.unique": self.fake.unique.random_int,
-            "JSONField": partial(
-                self.fake.pydict,
-                value_types=["str"],
-            ),  # No unique variant
-            "PositiveBigIntegerField": self.fake.random_int,
-            "PositiveBigIntegerField.unique": self.fake.unique.random_int,
-            "PositiveIntegerField": self.fake.random_int,
-            "PositiveIntegerField.unique": self.fake.unique.random_int,
-            "PositiveSmallIntegerField": self.fake.random_int,
-            "PositiveSmallIntegerField.unique": self.fake.unique.random_int,
-            "RichTextField": self.fake.paragraph,
-            "RichTextField.unique": self.fake.unique.paragraph,
-            "SlugField": self.fake.pystr,
-            "SlugField.unique": self.fake.unique.pystr,
-            "SmallIntegerField": self.fake.random_int,
-            "SmallIntegerField.unique": self.fake.unique.random_int,
-            "TextField": self.fake.paragraph,
-            "TextField.unique": self.fake.unique.paragraph,
-            "URLField": self.fake.url,
-            "URLField.unique": self.fake.unique.url,
-        }
+        fieldtype_overrides = MappingProxyType(
+            {
+                "BigIntegerField": self.fake.random_int,
+                "BigIntegerField.unique": self.fake.unique.random_int,
+                "BooleanField": self.fake.boolean,  # No unique varit
+                "CharField": self.fake.pystr,
+                "CharField.unique": self.fake.unique.pystr,
+                "DateField": self.fake.date_this_decade,
+                "DateField.unique": self.fake.unique.date_this_decade,
+                "DateTimeField": self.fake.date_time_this_decade,
+                "DateTimeField.unique": self.fake.unique.date_time_this_decade,
+                "DecimalField": self.fake.random_int,
+                "DecimalField.unique": self.fake.unique.random_int,
+                "EmailField": self.fake.safe_email,
+                "EmailField.unique": self.fake.unique.safe_email,
+                "FloatField": self.fake.random_int,
+                "FloatField.unique": self.fake.unique.random_int,
+                "GenericIPAddressField": self.fake.ipv4,
+                "GenericIPAddressField.unique": self.fake.unique.ipv4,
+                "ImageField": anonymize_image_field,
+                "IntegerField": self.fake.random_int,
+                "IntegerField.unique": self.fake.unique.random_int,
+                "JSONField": partial(
+                    self.fake.pydict,
+                    value_types=["str"],
+                ),  # No unique variant
+                "PositiveBigIntegerField": self.fake.random_int,
+                "PositiveBigIntegerField.unique": self.fake.unique.random_int,
+                "PositiveIntegerField": self.fake.random_int,
+                "PositiveIntegerField.unique": self.fake.unique.random_int,
+                "PositiveSmallIntegerField": self.fake.random_int,
+                "PositiveSmallIntegerField.unique": self.fake.unique.random_int,
+                "RichTextField": self.fake.paragraph,
+                "RichTextField.unique": self.fake.unique.paragraph,
+                "SlugField": self.fake.pystr,
+                "SlugField.unique": self.fake.unique.pystr,
+                "SmallIntegerField": self.fake.random_int,
+                "SmallIntegerField.unique": self.fake.unique.random_int,
+                "TextField": self.fake.paragraph,
+                "TextField.unique": self.fake.unique.paragraph,
+                "URLField": self.fake.url,
+                "URLField.unique": self.fake.unique.url,
+            }
+        )
 
         return fieldtype_overrides | (self.extra_fieldtype_overrides or {})
 
@@ -240,8 +243,10 @@ class BaseAnonymizer:
         return qs_overrides
 
     def get_field_overrides(self) -> Mapping[str, AllowedOverrides]:
-        field_overrides = {
-            f"{settings.AUTH_USER_MODEL}.first_name": self.fake.first_name,
-            f"{settings.AUTH_USER_MODEL}.last_name": self.fake.last_name,
-        }
+        field_overrides = MappingProxyType(
+            {
+                f"{settings.AUTH_USER_MODEL}.first_name": self.fake.first_name,
+                f"{settings.AUTH_USER_MODEL}.last_name": self.fake.last_name,
+            }
+        )
         return field_overrides | (self.extra_field_overrides or {})

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -62,7 +62,12 @@ def is_anonymizer_function(function: AllowedOverrides) -> TypeIs[AnonymizerFunct
     non_default_parameters = [
         parameter
         for parameter in parameters.values()
-        if parameter.default == inspect.Parameter.empty
+        if parameter.kind
+        not in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+            inspect.Parameter.EMPTY,
+        )
     ]
 
     if not non_default_parameters:
@@ -166,11 +171,13 @@ class BaseAnonymizer:
                             f"Unknown field type: '{field_type}'"
                         ) from None
 
+                    takes_arguments = is_anonymizer_function(value_func)
+
                     for obj in qs:
                         if getattr(obj, field_name) in EMPTY_VALUES:
                             continue
 
-                        if is_anonymizer_function(value_func):
+                        if takes_arguments:
                             new_value = value_func(obj=obj, field=field)
                         else:
                             new_value = value_func()
@@ -190,7 +197,7 @@ class BaseAnonymizer:
             {
                 "BigIntegerField": self.fake.random_int,
                 "BigIntegerField.unique": self.fake.unique.random_int,
-                "BooleanField": self.fake.boolean,  # No unique varit
+                "BooleanField": self.fake.boolean,  # No unique variant
                 "CharField": self.fake.pystr,
                 "CharField.unique": self.fake.unique.pystr,
                 "DateField": self.fake.date_this_decade,

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -185,55 +185,46 @@ class BaseAnonymizer:
 
     def get_fieldtype_overrides(self) -> Mapping[str, AllowedOverrides]:
         fieldtype_overrides = {
-            "BigIntegerField": lambda obj, field: self.fake.random_int(),
-            "BigIntegerField.unique": lambda obj, field: self.fake.unique.random_int(),
-            "BooleanField": lambda obj, field: self.fake.boolean(),  # No unique variant
-            "CharField": lambda obj, field: self.fake.pystr(),
-            "CharField.unique": lambda obj, field: self.fake.unique.pystr(),
-            "DateField": lambda obj, field: self.fake.date_this_decade(),
-            "DateField.unique": lambda obj, field: self.fake.unique.date_this_decade(),
-            "DateTimeField": lambda obj, field: self.fake.date_time_this_decade(),
-            "DateTimeField.unique": lambda obj, field: (
-                self.fake.unique.date_time_this_decade()
-            ),
-            "DecimalField": lambda obj, field: self.fake.random_int(),
-            "DecimalField.unique": lambda obj, field: self.fake.unique.random_int(),
-            "EmailField": lambda obj, field: self.fake.safe_email(),
-            "EmailField.unique": lambda obj, field: self.fake.unique.safe_email(),
-            "FloatField": lambda obj, field: self.fake.random_int(),
-            "FloatField.unique": lambda obj, field: self.fake.unique.random_int(),
-            "GenericIPAddressField": lambda obj, field: self.fake.ipv4(),
-            "GenericIPAddressField.unique": lambda obj, field: self.fake.unique.ipv4(),
+            "BigIntegerField": self.fake.random_int,
+            "BigIntegerField.unique": self.fake.unique.random_int,
+            "BooleanField": self.fake.boolean,  # No unique varit
+            "CharField": self.fake.pystr,
+            "CharField.unique": self.fake.unique.pystr,
+            "DateField": self.fake.date_this_decade,
+            "DateField.unique": self.fake.unique.date_this_decade,
+            "DateTimeField": self.fake.date_time_this_decade,
+            "DateTimeField.unique": self.fake.unique.date_time_this_decade,
+            "DecimalField": self.fake.random_int,
+            "DecimalField.unique": self.fake.unique.random_int,
+            "EmailField": self.fake.safe_email,
+            "EmailField.unique": self.fake.unique.safe_email,
+            "FloatField": self.fake.random_int,
+            "FloatField.unique": self.fake.unique.random_int,
+            "GenericIPAddressField": self.fake.ipv4,
+            "GenericIPAddressField.unique": self.fake.unique.ipv4,
             "ImageField": anonymize_image_field,
-            "IntegerField": lambda obj, field: self.fake.random_int(),
-            "IntegerField.unique": lambda obj, field: self.fake.unique.random_int(),
-            "JSONField": lambda obj, field: self.fake.pydict(
-                value_types=["str"]
+            "IntegerField": self.fake.random_int,
+            "IntegerField.unique": self.fake.unique.random_int,
+            "JSONField": partial(
+                self.fake.pydict,
+                value_types=["str"],
             ),  # No unique variant
-            "PositiveBigIntegerField": lambda obj, field: self.fake.random_int(),
-            "PositiveBigIntegerField.unique": lambda obj, field: (
-                self.fake.unique.random_int()
-            ),
-            "PositiveIntegerField": lambda obj, field: self.fake.random_int(),
-            "PositiveIntegerField.unique": lambda obj, field: (
-                self.fake.unique.random_int()
-            ),
-            "PositiveSmallIntegerField": lambda obj, field: self.fake.random_int(),
-            "PositiveSmallIntegerField.unique": lambda obj, field: (
-                self.fake.unique.random_int()
-            ),
-            "RichTextField": lambda obj, field: self.fake.paragraph(),
-            "RichTextField.unique": lambda obj, field: self.fake.unique.paragraph(),
-            "SlugField": lambda obj, field: self.fake.pystr(),
-            "SlugField.unique": lambda obj, field: self.fake.unique.pystr(),
-            "SmallIntegerField": lambda obj, field: self.fake.random_int(),
-            "SmallIntegerField.unique": lambda obj, field: (
-                self.fake.unique.random_int()
-            ),
-            "TextField": lambda obj, field: self.fake.paragraph(),
-            "TextField.unique": lambda obj, field: self.fake.unique.paragraph(),
-            "URLField": lambda obj, field: self.fake.url(),
-            "URLField.unique": lambda obj, field: self.fake.unique.url(),
+            "PositiveBigIntegerField": self.fake.random_int,
+            "PositiveBigIntegerField.unique": self.fake.unique.random_int,
+            "PositiveIntegerField": self.fake.random_int,
+            "PositiveIntegerField.unique": self.fake.unique.random_int,
+            "PositiveSmallIntegerField": self.fake.random_int,
+            "PositiveSmallIntegerField.unique": self.fake.unique.random_int,
+            "RichTextField": self.fake.paragraph,
+            "RichTextField.unique": self.fake.unique.paragraph,
+            "SlugField": self.fake.pystr,
+            "SlugField.unique": self.fake.unique.pystr,
+            "SmallIntegerField": self.fake.random_int,
+            "SmallIntegerField.unique": self.fake.unique.random_int,
+            "TextField": self.fake.paragraph,
+            "TextField.unique": self.fake.unique.paragraph,
+            "URLField": self.fake.url,
+            "URLField.unique": self.fake.unique.url,
         }
 
         return fieldtype_overrides | (self.extra_fieldtype_overrides or {})
@@ -250,11 +241,7 @@ class BaseAnonymizer:
 
     def get_field_overrides(self) -> Mapping[str, AllowedOverrides]:
         field_overrides = {
-            f"{settings.AUTH_USER_MODEL}.first_name": lambda obj, field: (
-                self.fake.first_name
-            ),
-            f"{settings.AUTH_USER_MODEL}.last_name": lambda obj, field: (
-                self.fake.last_name
-            ),
+            f"{settings.AUTH_USER_MODEL}.first_name": self.fake.first_name,
+            f"{settings.AUTH_USER_MODEL}.last_name": self.fake.last_name,
         }
         return field_overrides | (self.extra_field_overrides or {})

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -1,7 +1,10 @@
+import inspect
 import uuid
 
+from collections.abc import Callable, Mapping
+from functools import partial
 from importlib import resources
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeIs
 
 from faker import Faker
 
@@ -34,6 +37,39 @@ class AnonymizerFunction(Protocol):
             field: the field on the django model which is anonymized
         """
         ...
+
+
+AllowedOverrides = AnonymizerFunction | Callable[[], Any]
+
+
+def is_anonymizer_function(function: AllowedOverrides) -> TypeIs[AnonymizerFunction]:
+    """Check whether override function is a AnonymizerFunction or plain function.
+
+    Returns True if `function` should take the AnonymizerFunction parameters when called
+    and false if the function (can and) should take no arguments when called.
+
+    If the function is neither a AnonymizerFunction nor a function which needs no
+    arguments a TypeError is raised.
+    """
+
+    parameters = inspect.signature(function).parameters
+
+    if set(parameters.keys()) == {"obj", "field"}:
+        return True
+
+    non_default_parameters = [
+        parameter
+        for parameter in parameters.values()
+        if parameter.default == inspect.Parameter.empty
+    ]
+
+    if not non_default_parameters:
+        return False
+
+    raise TypeError(
+        "Given function is neither a AnonymizerFunction nor a callable without any "
+        "arguments that need to be provided."
+    )
 
 
 def anonymize_image_field(obj: Model, field: Field) -> ImageFieldFile:
@@ -80,9 +116,9 @@ class BaseAnonymizer:
     """
 
     excluded_fields = []
-    extra_fieldtype_overrides: dict[str, AnonymizerFunction] | None = None
+    extra_fieldtype_overrides: dict[str, AllowedOverrides] | None = None
     extra_qs_overrides = None
-    extra_field_overrides: dict[str, AnonymizerFunction] | None = None
+    extra_field_overrides: dict[str, AllowedOverrides] | None = None
 
     def __init__(self):
         self.fake = Faker(["nl-NL"])
@@ -129,9 +165,16 @@ class BaseAnonymizer:
                         ) from None
 
                     for obj in qs:
-                        if getattr(obj, field_name) not in EMPTY_VALUES:
-                            setattr(obj, field_name, value_func(obj=obj, field=field))
-                            fields_to_update.add(field_name)
+                        if getattr(obj, field_name) in EMPTY_VALUES:
+                            continue
+
+                        if is_anonymizer_function(value_func):
+                            new_value = value_func(obj=obj, field=field)
+                        else:
+                            new_value = value_func()
+
+                        setattr(obj, field_name, new_value)
+                        fields_to_update.add(field_name)
 
                 if fields_to_update:
                     Model.objects.bulk_update(
@@ -140,7 +183,7 @@ class BaseAnonymizer:
                         batch_size=500,
                     )
 
-    def get_fieldtype_overrides(self) -> dict[str, AnonymizerFunction]:
+    def get_fieldtype_overrides(self) -> Mapping[str, AllowedOverrides]:
         fieldtype_overrides = {
             "BigIntegerField": lambda obj, field: self.fake.random_int(),
             "BigIntegerField.unique": lambda obj, field: self.fake.unique.random_int(),
@@ -205,7 +248,7 @@ class BaseAnonymizer:
             qs_overrides.update(self.extra_qs_overrides)
         return qs_overrides
 
-    def get_field_overrides(self) -> dict[str, AnonymizerFunction]:
+    def get_field_overrides(self) -> Mapping[str, AllowedOverrides]:
         field_overrides = {
             f"{settings.AUTH_USER_MODEL}.first_name": lambda obj, field: (
                 self.fake.first_name
@@ -214,6 +257,4 @@ class BaseAnonymizer:
                 self.fake.last_name
             ),
         }
-        if self.extra_field_overrides is not None:
-            field_overrides.update(self.extra_field_overrides)
-        return field_overrides
+        return field_overrides | (self.extra_field_overrides or {})

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -63,11 +63,11 @@ def is_anonymizer_function(function: AllowedOverrides) -> TypeIs[AnonymizerFunct
         parameter
         for parameter in parameters.values()
         if parameter.kind
-        not in (
+        not in {
             inspect.Parameter.VAR_POSITIONAL,
             inspect.Parameter.VAR_KEYWORD,
-            inspect.Parameter.EMPTY,
-        )
+        }
+        and parameter.default == inspect.Parameter.empty
     ]
 
     if not non_default_parameters:

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -5,9 +5,10 @@ from collections.abc import Callable, Mapping
 from functools import partial
 from importlib import resources
 from types import MappingProxyType
-from typing import Any, Protocol, TypeIs
+from typing import Any, Protocol
 
 from faker import Faker
+from typing_extensions import TypeIs
 
 from django.apps import apps
 from django.conf import settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "django>=4.2",
     "pillow>=11.3.0",
     "pyyaml",
+    "typing-extensions>=4.14.1",
 ]
 readme = "README.md"
 license = "MIT"

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -251,11 +251,15 @@ class IsAnonymizerFunctionTest(TestCase):
         def with_defaults(arg, default_arg=None):
             pass
 
+        def anonymizer_function_with_extra(obj, field, extra):
+            pass
+
         self.assertFalse(is_anonymizer_function(partial(needs_arguments, arg=None)))
         self.assertFalse(is_anonymizer_function(partial(with_defaults, arg=None)))
         self.assertFalse(
             is_anonymizer_function(partial(with_defaults, arg=None, default_arg=None))
         )
+        self.assertTrue(partial(anonymizer_function_with_extra, extra=None))
 
     def test_varargs(self) -> None:
         def with_args(*args):

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -256,3 +256,20 @@ class IsAnonymizerFunctionTest(TestCase):
         self.assertFalse(
             is_anonymizer_function(partial(with_defaults, arg=None, default_arg=None))
         )
+
+    def test_varargs(self) -> None:
+        def with_args(*args):
+            pass
+
+        def with_kwargs(**kwargs):
+            pass
+
+        def with_args_and_kwargs(*args, **kwargs):
+            pass
+
+        self.assertFalse(is_anonymizer_function(with_args))
+        self.assertFalse(is_anonymizer_function(with_kwargs))
+        self.assertFalse(is_anonymizer_function(with_args_and_kwargs))
+
+        self.assertFalse(is_anonymizer_function(lambda *args: None))
+        self.assertFalse(is_anonymizer_function(lambda **kwargs: None))

--- a/tests/test_anonymizer.py
+++ b/tests/test_anonymizer.py
@@ -1,3 +1,4 @@
+from functools import partial
 from pathlib import Path
 from unittest import mock
 
@@ -6,7 +7,7 @@ from faker import Faker
 from django.core.files.base import ContentFile
 from django.test import TestCase
 
-from leukeleu_django_gdpr.anonymize import BaseAnonymizer
+from leukeleu_django_gdpr.anonymize import BaseAnonymizer, is_anonymizer_function
 from tests.custom_users.models import CustomUser
 
 
@@ -137,7 +138,7 @@ class AnonymizerTest(TestCase):
     def test_extra_fieldtypes(self):
         class Anonymizer(BaseAnonymizer):
             extra_fieldtype_overrides = {
-                "CharField": lambda obj, field: "Foo",
+                "CharField": lambda: "Foo",
             }
 
             def get_field_overrides(self):
@@ -165,7 +166,7 @@ class AnonymizerTest(TestCase):
     def test_extra_field_overrides(self):
         class Anonymizer(BaseAnonymizer):
             extra_field_overrides = {
-                "custom_users.CustomUser.username": lambda obj, field: "Foo",
+                "custom_users.CustomUser.username": lambda: "Foo",
             }
 
         self.assertEqual(self.user.username, "User")
@@ -206,3 +207,52 @@ class AnonymizerTest(TestCase):
         with mock.patch.object(CustomUser.objects, "bulk_update") as mock_bulk_update:
             BaseAnonymizer().anonymize()
             self.assertRaises(AssertionError, mock_bulk_update.assert_called_once)
+
+
+class IsAnonymizerFunctionTest(TestCase):
+    def test_named_functions(self) -> None:
+        def no_arguments():
+            pass
+
+        def default_arguments(arg="test"):
+            pass
+
+        def anonymizer_function(obj, field):
+            pass
+
+        def needs_arguments(arg):
+            pass
+
+        def needs_keyword_arguments(*, kwarg):
+            pass
+
+        self.assertFalse(is_anonymizer_function(no_arguments))
+        self.assertFalse(is_anonymizer_function(default_arguments))
+        self.assertTrue(is_anonymizer_function(anonymizer_function))
+
+        with self.assertRaises(TypeError):
+            is_anonymizer_function(needs_arguments)
+
+        with self.assertRaises(TypeError):
+            is_anonymizer_function(needs_keyword_arguments)
+
+    def test_lambdas(self) -> None:
+        self.assertFalse(is_anonymizer_function(lambda: None))
+        self.assertFalse(is_anonymizer_function(lambda arg="test": None))
+        self.assertTrue(is_anonymizer_function(lambda obj, field: None))
+
+        with self.assertRaises(TypeError):
+            is_anonymizer_function(lambda arg: None)
+
+    def test_partial(self) -> None:
+        def needs_arguments(arg):
+            pass
+
+        def with_defaults(arg, default_arg=None):
+            pass
+
+        self.assertFalse(is_anonymizer_function(partial(needs_arguments, arg=None)))
+        self.assertFalse(is_anonymizer_function(partial(with_defaults, arg=None)))
+        self.assertFalse(
+            is_anonymizer_function(partial(with_defaults, arg=None, default_arg=None))
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,7 @@ dependencies = [
     { name = "django" },
     { name = "pillow" },
     { name = "pyyaml" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -158,6 +159,7 @@ requires-dist = [
     { name = "faker", marker = "extra == 'anonymize'" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "pyyaml" },
+    { name = "typing-extensions", specifier = ">=4.14.1" },
 ]
 provides-extras = ["anonymize"]
 


### PR DESCRIPTION
Using this the user can either provide a function that takes the obj and field arguments or any function that doesn't take any function (like faker functions). This removes the need for all the lambda: obj, field for all overrides while keeping the type hinting intact (so you still get LSP errors if they provide an override function that requires arguments the Anonymizer will not provide).