### PR TITLE
Allow field overrides even if there is not fieldtype override

### DIFF
--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -161,14 +161,13 @@ class BaseAnonymizer:
                     if field.unique:
                         field_type += ".unique"
 
-                    try:
-                        value_func = field_overrides.get(
-                            field_path,
-                            fieldtype_overrides[field_type],
-                        )
-                    except KeyError:
+                    value_func = field_overrides.get(
+                        field_path, fieldtype_overrides.get(field_type)
+                    )
+
+                    if not value_func:
                         raise ImproperlyConfigured(
-                            f"Unknown field type: '{field_type}'"
+                            f"No anonymization method found for field '{field_path}' with type '{field_type}'."
                         ) from None
 
                     takes_arguments = is_anonymizer_function(value_func)

--- a/leukeleu_django_gdpr/anonymize.py
+++ b/leukeleu_django_gdpr/anonymize.py
@@ -167,7 +167,8 @@ class BaseAnonymizer:
 
                     if not value_func:
                         raise ImproperlyConfigured(
-                            f"No anonymization method found for field '{field_path}' with type '{field_type}'."
+                            f"No anonymization method found for field '{field_path}' "
+                            f"with type '{field_type}'."
                         ) from None
 
                     takes_arguments = is_anonymizer_function(value_func)


### PR DESCRIPTION
The default value for field_overrides.get is evaluated eagerly so not using get there requires fieldtype_overrides to have a key for the field type defined (even though that's not really necessary.